### PR TITLE
No matrix build option

### DIFF
--- a/gen_data/gen-suite-matrix.py
+++ b/gen_data/gen-suite-matrix.py
@@ -1,5 +1,6 @@
 import json
 import glob
+import os
 
 SUITES_DIR="./suites/*"
 
@@ -17,9 +18,11 @@ def generate_matrix_json() -> str:
 		for variantPath in glob.iglob(f"{SUITES_DIR}/*", recursive=False):
 			suiteName = variantPath.split('/')[2]
 			variantName = variantPath.split('/')[3]
-			
-			element = { }
-			
+
+			if os.path.exists(f"{variantPath}/.no-matrix-build"):
+				continue
+
+			element = { }		
 			element['suite'] = suiteName
 			element['variant'] = variantName
 			element['architecture'] = arch

--- a/suites/focal/raw/.no-matrix-build
+++ b/suites/focal/raw/.no-matrix-build
@@ -1,0 +1,1 @@
+prevents this distro from building in github actions

--- a/suites/kinetic/gnomeRaw/.no-matrix-build
+++ b/suites/kinetic/gnomeRaw/.no-matrix-build
@@ -1,0 +1,1 @@
+prevents this distro from building in github actions

--- a/suites/kinetic/raw/.no-matrix-build
+++ b/suites/kinetic/raw/.no-matrix-build
@@ -1,0 +1,1 @@
+prevents this distro from building in github actions


### PR DESCRIPTION
- adds a way to skip building a varient without deleting or moving build scripts
- update fs-cook to latest commit